### PR TITLE
Revision vars balance and transfer from int32 to int64

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,8 +3,8 @@ package main
 import "fmt"
 
 func main() {
-	var balance int32 = 1500000000       // 15 миллионов в копейках
-	var transfer int32 = 1000000000      // 10 миллионов в копейках
+	var balance int64 = 1500000000       // 15 миллионов в копейках
+	var transfer int64 = 1000000000      // 10 миллионов в копейках
 	total := balance + transfer // int32 + int32 будет int32
 	fmt.Println(total)
 }


### PR DESCRIPTION
## Проблема

Проблема заключается в том, что переменные имеют тип **int32** и при получении суммы в переменной **total** значение тоже имеет int32, поэтому происходит смещение знакового бита из-за переполнения переменной

## Решение

Требуется заменить типы переменных у:
`var balance int32`
`var transfer int32`

на 
`var balance int64`
`var transfer int64`

Что сделано в данном PULL-REQUEST
